### PR TITLE
Use addAssets to add font files.

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,9 +6,11 @@ Package.describe({
 });
 
 Package.onUse(function (api){
-  api.addFiles('lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.eot', 'client');
-  api.addFiles('lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.svg', 'client');
-  api.addFiles('lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.ttf', 'client');
-  api.addFiles('lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.woff', 'client');
+  api.addAssets([
+    'lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.eot',
+    'lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.svg',
+    'lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.ttf',
+    'lib/glyphicons-halflings/fonts/glyphicons-halflings-regular.woff'
+  ], 'client');
   api.addFiles('lib/glyphicons-halflings/css/glyphicons.css', 'client');
 });


### PR DESCRIPTION
Since v1.2, 2015-Sept-21:
  Backwards-incompatible change for package authors: Static assets in
  package.js files must now be explicitly declared by using addAssets
  instead of addFiles. Previously, any file that didn't have a source
  handler was automatically registered as a server-side asset. The
  isAsset option to addFiles is also deprecated in favor of addAssets.

  https://github.com/meteor/meteor/blob/devel/History.md
